### PR TITLE
feat: add scaleSmoothing option for smoother pinch-zoom gestures

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ See this [stackoverflow question](https://stackoverflow.com/questions/70428922/p
 
 > **Panzoom**(`elem`, `options`?): `[PanzoomObject](#PanzoomObject)`
 
-Defined in: [panzoom.ts:60](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/panzoom.ts#L60)
+Defined in: [panzoom.ts:60](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/panzoom.ts#L60)
 
 ## Parameters
 
@@ -181,7 +181,7 @@ Identical to PanzoomOptions, but excludes the `force` option.
 
 These options can be passed to `Panzoom()`, as well as any pan or zoom function. One exception is `force`, which can only be passed to methods like `pan()` or `zoom()`, but not `Panzoom()` or `setOptions()` as it should not be set globally.
 
-Defined in: [types.ts:19](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L19)
+Defined in: [types.ts:19](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L19)
 
 ## Indexable
 
@@ -193,7 +193,7 @@ Defined in: [types.ts:19](https://github.com/timmywil/panzoom/blob/8e773ae5650ee
 
 > `optional` **animate**: `boolean` (Default: **false**)
 
-Defined in: [types.ts:21](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L21)
+Defined in: [types.ts:21](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L21)
 
 Whether to animate transitions
 
@@ -203,7 +203,7 @@ Whether to animate transitions
 
 > `optional` **canvas**: `boolean` (Default: **false**)
 
-Defined in: [types.ts:32](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L32)
+Defined in: [types.ts:32](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L32)
 
 This option treats the Panzoom element's parent
 as a canvas. Effectively, Panzoom binds the
@@ -220,7 +220,7 @@ where the `cursor` style is applied (i.e. the parent).
 
 > `optional` **duration**: `number` (Default: **200**)
 
-Defined in: [types.ts:34](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L34)
+Defined in: [types.ts:34](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L34)
 
 Duration of the transition (ms)
 
@@ -230,7 +230,7 @@ Duration of the transition (ms)
 
 > `optional` **easing**: `string` (Default: **"ease-in-out"**)
 
-Defined in: [types.ts:36](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L36)
+Defined in: [types.ts:36](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L36)
 
 CSS Easing used for transitions
 
@@ -240,7 +240,7 @@ CSS Easing used for transitions
 
 > `optional` **exclude**: `Element`[] (Default: **[]**)
 
-Defined in: [types.ts:43](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L43)
+Defined in: [types.ts:43](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L43)
 
 Add elements to this array that should be excluded
 from Panzoom handling.
@@ -253,7 +253,7 @@ e.g. links and buttons that should not propagate the click event.
 
 > `optional` **excludeClass**: `string` (Default: **"panzoom-exclude"**)
 
-Defined in: [types.ts:50](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L50)
+Defined in: [types.ts:50](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L50)
 
 Add this class to any element within the Panzoom element
 that you want to exclude from Panzoom handling. That
@@ -266,7 +266,7 @@ e.g. links and buttons that should not propagate the click event.
 
 > `optional` **force**: `boolean`
 
-Defined in: [types.ts:67](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L67)
+Defined in: [types.ts:67](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L67)
 
 The `force` option can only be passed directly
 to zoom and pan methods. It is not a global option
@@ -294,7 +294,7 @@ panzoom.zoom(1, { force: true })
 
 }\*\*)
 
-Defined in: [types.ts:92](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L92)
+Defined in: [types.ts:92](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L92)
 
 On the first pointer event, when panning starts,
 the default Panzoom behavior is to call
@@ -335,7 +335,7 @@ Panzoom(elem, {
 
 > `optional` **noBind**: `boolean`
 
-Defined in: [types.ts:96](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L96)
+Defined in: [types.ts:96](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L96)
 
 Skip binding the default Panzoom event listeners
 
@@ -345,7 +345,7 @@ Skip binding the default Panzoom event listeners
 
 > `optional` **origin**: `string`
 
-Defined in: [types.ts:110](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L110)
+Defined in: [types.ts:110](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L110)
 
 **Change this at your own risk.**
 The `transform-origin` is the origin from which transforms are applied.
@@ -365,7 +365,7 @@ And again, changing this for SVG in IE doesn't work at all.
 
 > `optional` **overflow**: `string` (Default: **"hidden"**)
 
-Defined in: [types.ts:112](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L112)
+Defined in: [types.ts:112](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L112)
 
 The overflow CSS value for the parent. Defaults to 'hidden'
 
@@ -375,7 +375,7 @@ The overflow CSS value for the parent. Defaults to 'hidden'
 
 > `optional` **pinchAndPan**: `boolean` (Default: **false**)
 
-Defined in: [types.ts:125](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L125)
+Defined in: [types.ts:125](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L125)
 
 Set to true to enable panning during pinch zoom.
 Note: this is zooming to a point and panning in the same
@@ -394,7 +394,7 @@ https://github.com/timmywil/panzoom/issues/606
 
 > `optional` **setTransform**: (`elem`, `__namedParameters`, `_options`?) => `void`
 
-Defined in: [types.ts:129](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L129)
+Defined in: [types.ts:129](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L129)
 
 Set the transform using the proper prefix.
 
@@ -440,7 +440,7 @@ const panzoom = Panzoom(elem, {
 
 > `optional` **silent**: `boolean`
 
-Defined in: [types.ts:131](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L131)
+Defined in: [types.ts:131](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L131)
 
 Silence all events
 
@@ -450,7 +450,7 @@ Silence all events
 
 > `optional` **startScale**: `number` (Default: **1**)
 
-Defined in: [types.ts:137](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L137)
+Defined in: [types.ts:137](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L137)
 
 Scale used to set the beginning transform
 
@@ -460,7 +460,7 @@ Scale used to set the beginning transform
 
 > `optional` **startX**: `number` (Default: **0**)
 
-Defined in: [types.ts:133](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L133)
+Defined in: [types.ts:133](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L133)
 
 X Value used to set the beginning transform
 
@@ -470,7 +470,7 @@ X Value used to set the beginning transform
 
 > `optional` **startY**: `number` (Default: **0**)
 
-Defined in: [types.ts:135](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L135)
+Defined in: [types.ts:135](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L135)
 
 Y Value used to set the beginning transform
 
@@ -480,7 +480,7 @@ Y Value used to set the beginning transform
 
 > `optional` **touchAction**: `string` (Default: **"none"**)
 
-Defined in: [types.ts:147](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L147)
+Defined in: [types.ts:147](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L147)
 
 This value is used to set touch-action on both the
 Panzoom element and its parent.
@@ -492,7 +492,7 @@ cannot work at the same time.
 
 ## PanOptions (includes MiscOptions)
 
-Defined in: [types.ts:152](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L152)
+Defined in: [types.ts:152](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L152)
 
 ## Properties
 
@@ -500,7 +500,7 @@ Defined in: [types.ts:152](https://github.com/timmywil/panzoom/blob/8e773ae5650e
 
 > `optional` **contain**: `"inside"` \| `"outside"`
 
-Defined in: [types.ts:166](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L166)
+Defined in: [types.ts:166](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L166)
 
 Contain the panzoom element either
 inside or outside the parent.
@@ -520,7 +520,7 @@ empty space around the element will be shown.
 
 > `optional` **cursor**: `string` (Default: **"move"**)
 
-Defined in: [types.ts:168](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L168)
+Defined in: [types.ts:168](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L168)
 
 The cursor style to set on the panzoom element
 
@@ -530,7 +530,7 @@ The cursor style to set on the panzoom element
 
 > `optional` **disablePan**: `boolean` (Default: **false**)
 
-Defined in: [types.ts:174](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L174)
+Defined in: [types.ts:174](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L174)
 
 Disable panning functionality.
 Note: disablePan does not affect focal point zooming or the contain option.
@@ -542,7 +542,7 @@ The element will still pan accordingly.
 
 > `optional` **disableXAxis**: `boolean` (Default: **false**)
 
-Defined in: [types.ts:176](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L176)
+Defined in: [types.ts:176](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L176)
 
 Pan only on the Y axis
 
@@ -552,7 +552,7 @@ Pan only on the Y axis
 
 > `optional` **disableYAxis**: `boolean` (Default: **false**)
 
-Defined in: [types.ts:178](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L178)
+Defined in: [types.ts:178](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L178)
 
 Pan only on the X axis
 
@@ -562,7 +562,7 @@ Pan only on the X axis
 
 > `optional` **panOnlyWhenZoomed**: `boolean` (Default: **false**)
 
-Defined in: [types.ts:182](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L182)
+Defined in: [types.ts:182](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L182)
 
 Disable panning while the scale is equal to the starting value
 
@@ -572,7 +572,7 @@ Disable panning while the scale is equal to the starting value
 
 > `optional` **relative**: `boolean` (Default: **false**)
 
-Defined in: [types.ts:180](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L180)
+Defined in: [types.ts:180](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L180)
 
 When passing x and y values to .pan(), treat the values as relative to their current values
 
@@ -582,7 +582,7 @@ When passing x and y values to .pan(), treat the values as relative to their cur
 
 > `optional` **roundPixels**: `boolean`
 
-Defined in: [types.ts:191](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L191)
+Defined in: [types.ts:191](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L191)
 
 Round x and y values to whole numbers.
 This can help prevent images and text from looking blurry,
@@ -593,7 +593,7 @@ zooming in when using this option.
 
 ## ZoomOptions (includes MiscOptions)
 
-Defined in: [types.ts:194](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L194)
+Defined in: [types.ts:194](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L194)
 
 ## Properties
 
@@ -601,7 +601,7 @@ Defined in: [types.ts:194](https://github.com/timmywil/panzoom/blob/8e773ae5650e
 
 > `optional` **disableZoom**: `boolean` (Default: **false**)
 
-Defined in: [types.ts:196](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L196)
+Defined in: [types.ts:196](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L196)
 
 Disable zooming functionality
 
@@ -611,7 +611,7 @@ Disable zooming functionality
 
 > `optional` **focal**: `object`
 
-Defined in: [types.ts:203](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L203)
+Defined in: [types.ts:203](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L203)
 
 Zoom to the given point on the panzoom element.
 This point is expected to be relative to
@@ -632,7 +632,7 @@ to the parent dimensions.
 
 > `optional` **maxScale**: `number` (Default: **4**)
 
-Defined in: [types.ts:207](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L207)
+Defined in: [types.ts:207](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L207)
 
 The maximum scale when zooming
 
@@ -642,9 +642,27 @@ The maximum scale when zooming
 
 > `optional` **minScale**: `number` (Default: **0.125**)
 
-Defined in: [types.ts:205](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L205)
+Defined in: [types.ts:205](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L205)
 
 The minimum scale when zooming
+
+---
+
+### scaleSmoothing?
+
+> `optional` **scaleSmoothing**: `number`
+
+Defined in: [types.ts:220](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L220)
+
+Smoothing factor for scale transitions during zoom operations.
+A value of 0 (default) disables smoothing, applying scale changes immediately.
+A value between 0 and 1 (e.g., 0.5) blends the new scale with the current scale,
+reducing trembling during fast pinch gestures on touchscreens.
+Example:
+
+```js
+Panzoom(elem, { scaleSmoothing: 0.5 })
+```
 
 ---
 
@@ -652,7 +670,7 @@ The minimum scale when zooming
 
 > `optional` **step**: `number` (Default: **0.3**)
 
-Defined in: [types.ts:209](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L209)
+Defined in: [types.ts:209](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L209)
 
 The step affects zoom calculation when zooming with a mouse wheel, when pinch zooming, or when using zoomIn/zoomOut
 
@@ -660,7 +678,7 @@ The step affects zoom calculation when zooming with a mouse wheel, when pinch zo
 
 These methods are available after initializing Panzoom.
 
-Defined in: [types.ts:226](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L226)
+Defined in: [types.ts:237](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L237)
 
 ## Properties
 
@@ -668,7 +686,7 @@ Defined in: [types.ts:226](https://github.com/timmywil/panzoom/blob/8e773ae5650e
 
 > **bind**: () => `void`
 
-Defined in: [types.ts:239](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L239)
+Defined in: [types.ts:250](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L250)
 
 Bind the default down, move, and up event listeners to the Panzoom element.
 This does not normally need to be called.
@@ -691,7 +709,7 @@ panzoom.bind()
 
 > **destroy**: () => `void`
 
-Defined in: [types.ts:241](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L241)
+Defined in: [types.ts:252](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L252)
 
 Remove all event listeners bound to the the Panzoom element
 
@@ -705,7 +723,7 @@ Remove all event listeners bound to the the Panzoom element
 
 > **eventNames**: `object`
 
-Defined in: [types.ts:247](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L247)
+Defined in: [types.ts:258](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L258)
 
 This object exposes the event names used by Panzoom,
 depending on the current browser's support for
@@ -729,7 +747,7 @@ Pointer or Touch events.
 
 > **getOptions**: () => `PanzoomOptions`
 
-Defined in: [types.ts:253](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L253)
+Defined in: [types.ts:264](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L264)
 
 Returns a _copy_ of the current options object
 
@@ -743,7 +761,7 @@ Returns a _copy_ of the current options object
 
 > **getPan**: () => `object`
 
-Defined in: [types.ts:249](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L249)
+Defined in: [types.ts:260](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L260)
 
 Get the current x/y translation
 
@@ -765,7 +783,7 @@ Get the current x/y translation
 
 > **getScale**: () => `number`
 
-Defined in: [types.ts:251](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L251)
+Defined in: [types.ts:262](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L262)
 
 Get the current scale
 
@@ -779,7 +797,7 @@ Get the current scale
 
 > **handleDown**: (`event`) => `void`
 
-Defined in: [types.ts:275](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L275)
+Defined in: [types.ts:286](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L286)
 
 handleDown, handleMove, and handleUp
 are the exact event handlers that Panzoom
@@ -817,7 +835,7 @@ document.addEventListener('pointerup', panzoom.handleUp)
 
 > **handleMove**: (`event`) => `void`
 
-Defined in: [types.ts:276](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L276)
+Defined in: [types.ts:287](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L287)
 
 #### Parameters
 
@@ -835,7 +853,7 @@ Defined in: [types.ts:276](https://github.com/timmywil/panzoom/blob/8e773ae5650e
 
 > **handleUp**: (`event`) => `void`
 
-Defined in: [types.ts:277](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L277)
+Defined in: [types.ts:288](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L288)
 
 #### Parameters
 
@@ -853,7 +871,7 @@ Defined in: [types.ts:277](https://github.com/timmywil/panzoom/blob/8e773ae5650e
 
 > **pan**: (`x`, `y`, `panOptions`?) => `[CurrentValues](#CurrentValues)`
 
-Defined in: [types.ts:288](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L288)
+Defined in: [types.ts:299](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L299)
 
 Pan the Panzoom element to the given x and y coordinates
 
@@ -888,7 +906,7 @@ panzoom.pan(10, 10, { relative: true })
 
 > **reset**: (`resetOptions`?) => `[CurrentValues](#CurrentValues)`
 
-Defined in: [types.ts:301](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L301)
+Defined in: [types.ts:312](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L312)
 
 Reset the pan and zoom to startX, startY, and startScale.
 Animates by default, ignoring the global option.
@@ -917,7 +935,7 @@ panzoom.reset({ animate: false })
 
 > **resetStyle**: () => `void`
 
-Defined in: [types.ts:310](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L310)
+Defined in: [types.ts:321](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L321)
 
 Reset the styles set on the Panzoom element
 and its parent (such as overflow, cursor, etc.)
@@ -936,7 +954,7 @@ panzoom.resetStyle()
 
 > **setOptions**: (`options`?) => `void`
 
-Defined in: [types.ts:323](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L323)
+Defined in: [types.ts:334](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L334)
 
 Change any number of options on a Panzoom instance.
 Setting some options will have side-effects.
@@ -965,7 +983,7 @@ panzoom.setOptions({ cursor: 'default' })
 
 > **setStyle**: (`name`, `value`) => `void`
 
-Defined in: [types.ts:325](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L325)
+Defined in: [types.ts:336](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L336)
 
 A convenience method for setting prefixed styles on the Panzoom element
 
@@ -989,7 +1007,7 @@ A convenience method for setting prefixed styles on the Panzoom element
 
 > **zoom**: (`scale`, `zoomOptions`?) => `[CurrentValues](#CurrentValues)`
 
-Defined in: [types.ts:334](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L334)
+Defined in: [types.ts:345](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L345)
 
 Zoom the Panzoom element to the given scale
 
@@ -1018,7 +1036,7 @@ panzoom.zoom(2.2, { animate: true })
 
 > **zoomIn**: (`zoomOptions`?) => `[CurrentValues](#CurrentValues)`
 
-Defined in: [types.ts:345](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L345)
+Defined in: [types.ts:356](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L356)
 
 Zoom in using the predetermined increment set in options.
 Animates by default, ignoring the global option.
@@ -1045,7 +1063,7 @@ panzoom.zoomIn({ animate: false })
 
 > **zoomOut**: (`zoomOptions`?) => `[CurrentValues](#CurrentValues)`
 
-Defined in: [types.ts:356](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L356)
+Defined in: [types.ts:367](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L367)
 
 Zoom out using the predetermined increment set in options.
 Animates by default, ignoring the global option.
@@ -1072,7 +1090,7 @@ panzoom.zoomOut({ animate: false })
 
 > **zoomToPoint**: (`scale`, `point`, `zoomOptions`?) => `[CurrentValues](#CurrentValues)`
 
-Defined in: [types.ts:367](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L367)
+Defined in: [types.ts:378](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L378)
 
 Zoom the Panzoom element to a focal point using
 the given pointer/touch/mouse event or constructed point.
@@ -1113,7 +1131,7 @@ panzoom.zoomToPoint(1.2, pointerEvent)
 
 > **zoomWithWheel**: (`event`, `zoomOptions`?) => `[CurrentValues](#CurrentValues)`
 
-Defined in: [types.ts:400](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L400)
+Defined in: [types.ts:411](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L411)
 
 Zoom the Panzoom element to a focal point using the given WheelEvent
 
@@ -1158,7 +1176,7 @@ elem.parentElement.addEventListener('wheel', function (event) {
 
 ## $1
 
-Defined in: [types.ts:219](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L219)
+Defined in: [types.ts:230](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L230)
 
 ## Properties
 
@@ -1166,7 +1184,7 @@ Defined in: [types.ts:219](https://github.com/timmywil/panzoom/blob/8e773ae5650e
 
 > `optional` **isSVG**: `boolean`
 
-Defined in: [types.ts:223](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L223)
+Defined in: [types.ts:234](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L234)
 
 ---
 
@@ -1174,7 +1192,7 @@ Defined in: [types.ts:223](https://github.com/timmywil/panzoom/blob/8e773ae5650e
 
 > **scale**: `number`
 
-Defined in: [types.ts:222](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L222)
+Defined in: [types.ts:233](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L233)
 
 ---
 
@@ -1182,7 +1200,7 @@ Defined in: [types.ts:222](https://github.com/timmywil/panzoom/blob/8e773ae5650e
 
 > **x**: `number`
 
-Defined in: [types.ts:220](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L220)
+Defined in: [types.ts:231](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L231)
 
 ---
 
@@ -1190,7 +1208,7 @@ Defined in: [types.ts:220](https://github.com/timmywil/panzoom/blob/8e773ae5650e
 
 > **y**: `number`
 
-Defined in: [types.ts:221](https://github.com/timmywil/panzoom/blob/8e773ae5650ee83e61463a3f4441347468df3a61/src/types.ts#L221)
+Defined in: [types.ts:232](https://github.com/enhancer13/panzoom/blob/9efb1b23a0da18c98f5319f0edef7b10c4eb98d6/src/types.ts#L232)
 
 ## Events
 

--- a/src/panzoom.ts
+++ b/src/panzoom.ts
@@ -313,6 +313,11 @@ function Panzoom(elem: HTMLElement | SVGElement, options?: PanzoomGlobalOptions)
       return
     }
     toScale = result.scale
+    const scaleSmoothing = opts.scaleSmoothing
+    if (scaleSmoothing > 0 && scaleSmoothing <= 1) {
+      toScale = scaleSmoothing * result.scale + (1 - scaleSmoothing) * scale
+    }
+
     let toX = x
     let toY = y
 

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,4 +1,3 @@
- 
 if (typeof window !== 'undefined') {
   // Support: IE11 only
   if (window.NodeList && !NodeList.prototype.forEach) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -207,6 +207,17 @@ export interface ZoomOnlyOptions {
   maxScale?: number
   /** The step affects zoom calculation when zooming with a mouse wheel, when pinch zooming, or when using zoomIn/zoomOut */
   step?: number
+  /**
+   * Smoothing factor for scale transitions during zoom operations.
+   * A value of 0 (default) disables smoothing, applying scale changes immediately.
+   * A value between 0 and 1 (e.g., 0.5) blends the new scale with the current scale,
+   * reducing trembling during fast pinch gestures on touchscreens.
+   * Example:
+   * ```js
+   * Panzoom(elem, { scaleSmoothing: 0.5 })
+   * ```
+   */
+  scaleSmoothing?: number
 }
 
 export type PanOptions = MiscOptions & PanOnlyOptions

--- a/test/unit/panzoom.test.ts
+++ b/test/unit/panzoom.test.ts
@@ -468,4 +468,45 @@ QUnit.module('Panzoom', () => {
       document.body.removeChild(div)
     })
   })
+  QUnit.module('scaleSmoothing option', () => {
+    QUnit.test('smooths scale when value is between 0 and 1', (assert) => {
+      const div = document.createElement('div')
+      document.body.appendChild(div)
+      const panzoom = Panzoom(div, { scaleSmoothing: 0.5 })
+
+      panzoom.zoom(2)
+      assert.strictEqual(panzoom.getScale(), 1.5, 'Applies 50% smoothing on first zoom')
+
+      panzoom.zoom(3)
+      assert.strictEqual(panzoom.getScale(), 2.25, 'Applies 50% smoothing on subsequent zoom')
+
+      document.body.removeChild(div)
+    })
+
+    QUnit.test('disables smoothing when value is 0', (assert) => {
+      const div = document.createElement('div')
+      document.body.appendChild(div)
+      const panzoom = Panzoom(div, { scaleSmoothing: 0 })
+
+      panzoom.zoom(2)
+      assert.strictEqual(panzoom.getScale(), 2, 'Immediately applies target scale')
+
+      document.body.removeChild(div)
+    })
+
+    QUnit.test('ignores invalid values outside 0-1 range', (assert) => {
+      const div = document.createElement('div')
+      document.body.appendChild(div)
+      const panzoom = Panzoom(div, { scaleSmoothing: -0.1 })
+
+      panzoom.zoom(2)
+      assert.strictEqual(panzoom.getScale(), 2, 'Ignores negative values')
+
+      panzoom.setOptions({ scaleSmoothing: 1.1 })
+      panzoom.zoom(3)
+      assert.strictEqual(panzoom.getScale(), 3, 'Ignores values above 1')
+
+      document.body.removeChild(div)
+    })
+  })
 })


### PR DESCRIPTION
### PR Checklist
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.
- [x] I am requesting to pull a topic/feature/bugfix branch (right side). In other words, not _main_.
- [x] I have run `npm test` against my changes and tests pass.
- [x] I have added tests to prove my fix is effective or my feature works. This can be done in the form of unit tests in `test/unit/` or a new or altered demo in `demo/`.
- [x] I have added or edited necessary types and generated documentation (`npm run docs`), or no docs changes are needed.

### Description
This PR introduces a new `scaleSmoothing` option to address visual instability during rapid pinch-zoom gestures on mobile devices.

**Problem**: Fast pinch gestures on touchscreens caused trembling/jittering due to immediate scale changes between gesture events. Existing animation options weren't suitable for real-time gesture handling.

![before_fix](https://github.com/user-attachments/assets/bae25ba7-d9c7-44c6-af63-0b264148b7c6)

```js
  { scale: 1.253061, positions: [100,100,150,100] }, // +25.3%
  { scale: 1.175761, positions: [100,100,145,100] }, // -6.2%
  { scale: 0.947083, positions: [100,100,130,100] }, // -24.3% 
  { scale: 1.055873, positions: [100,100,140,100] }, // +11.5%
  { scale: 0.990737, positions: [100,100,135,100] }  // -6.5%
```

**Solution**:
- Implement frame blending using smoothing factor (0-1)
- `scaleSmoothing: 0` - Immediate scale changes (existing behavior)
- `scaleSmoothing: 0.5` - Blends 50% of new scale with 50% previous scale

![after_fix](https://github.com/user-attachments/assets/eef15fad-0346-4bc3-9212-b13da38ec6be)

